### PR TITLE
fix: disambiguate better between intents

### DIFF
--- a/locale/ca-es/intents/what.day.is.it.intent
+++ b/locale/ca-es/intents/what.day.is.it.intent
@@ -1,11 +1,14 @@
+avui quin dia és
 em pots dir quin dia és
 em pots dir quin dia és avui
 qualsevol dia d'avui
+quin dia tenim
 quin dia tenim avui
 quin dia és
 quin dia és avui
 quin és la data
 quin és la data d'avui
+saps quin dia tenim
 saps quin dia tenim avui
 saps quin dia és
 saps quin dia és avui

--- a/locale/ca-es/vocab/RelativeDay.voc
+++ b/locale/ca-es/vocab/RelativeDay.voc
@@ -1,7 +1,5 @@
 ahir
-avui
 d'ahir
-d'avui
 de demà
 demà
 dijous

--- a/locale/de-de/vocab/RelativeDay.voc
+++ b/locale/de-de/vocab/RelativeDay.voc
@@ -4,8 +4,6 @@ freitag
 gestern
 gestrig
 gestrigen
-heute
-heutig
 mittwoch
 montag
 morgen

--- a/locale/en-us/vocab/RelativeDay.voc
+++ b/locale/en-us/vocab/RelativeDay.voc
@@ -3,9 +3,6 @@ monday
 saturday
 sunday
 thursday
-today
-today's
-todays
 tomorrow
 tomorrow's
 tomorrows

--- a/translations/ca-es/intents.json
+++ b/translations/ca-es/intents.json
@@ -1,7 +1,7 @@
 {
   "/intents/what.day.is.it.intent": [
-    "[saps] quin dia és [avui]",
-    "[saps] quin dia tenim avui",
+    "[saps] quin dia (tenim|és) avui",
+    "[avui] quin dia és",
     "quin és la data [d'avui]",
     "em pots dir quin dia és [avui]",
     "qualsevol dia d'avui"

--- a/translations/ca-es/vocabs.json
+++ b/translations/ca-es/vocabs.json
@@ -48,9 +48,6 @@
     "dia"
   ],
   "/vocab/RelativeDay.voc": [
-    "avui",
-    "avui",
-    "d'avui",
     "demà",
     "demà",
     "de demà",

--- a/translations/de-de/vocabs.json
+++ b/translations/de-de/vocabs.json
@@ -48,9 +48,6 @@
     "tag"
   ],
   "/vocab/RelativeDay.voc": [
-    "heute",
-    "heutig",
-    "heutig",
     "morgen",
     "morgig",
     "morgigen",

--- a/translations/en-us/vocabs.json
+++ b/translations/en-us/vocabs.json
@@ -48,9 +48,6 @@
         "day"
     ],
     "/vocab/RelativeDay.voc": [
-        "today",
-        "todays",
-        "today's",
         "tomorrow",
         "tomorrows",
         "tomorrow's",


### PR DESCRIPTION
disambiguate better between handle_query_relative_date and handle_current_day_simple

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated relative day vocabulary across several languages by removing entries referring to the current day, including "today" in English, "heute" in German, and "avui" in Catalan.
  - Introduced new phrases for inquiring about the current day in Catalan, enhancing user interaction.
  - Streamlined vocabulary displays to improve clarity and consistency in user-facing language settings.
  - These refinements ensure a more cohesive and simplified experience when referencing relative day terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->